### PR TITLE
Add PTZ telemetry thread and CSV logging

### DIFF
--- a/shared_state.py
+++ b/shared_state.py
@@ -10,3 +10,6 @@ orthophoto_path: Optional[str] = None
 # נשמר כדי לצייר CAM גם בטאב Image→Ground
 # מבנה: {"x": float, "y": float, "epsg": int}
 camera_proj: Optional[Dict] = None
+
+# אחרון מצב וטלמטריית PTZ (מ-PtzMetaThread)
+ptz_meta: Optional[Dict] = None

--- a/ui_cam_module.py
+++ b/ui_cam_module.py
@@ -17,6 +17,7 @@ from camera_io import (
     probe_rtsp, sanitize_host, parse_host_from_rtsp,
     onvif_get_rtsp_uri, ONVIFCamera
 )
+from onvif_ptz import PtzMetaThread
 
 from ui_common import VlcVideoWidget, default_vlc_path, open_folder
 import shared_state  # <<< לשיתוף הגדרות ה-PTZ עם מודולים אחרים
@@ -43,6 +44,7 @@ class CameraModule(QtCore.QObject):
         self.hevc_guard_ms = 4000
         self._hevc_guard_tried = False
         self._last_codec = ""
+        self._ptz_meta: Optional[PtzMetaThread] = None
 
     # ---- public API for the shell ----
     def widget(self) -> QtWidgets.QWidget:
@@ -389,6 +391,7 @@ class CameraModule(QtCore.QObject):
             self._start_player(url, force_tcp=self.force_tcp.isChecked(), user=user, pwd=pwd)
             # פרסום הגדרות PTZ
             self._publish_ptz_cfg()
+            self._start_ptz_meta(h, int(self.onvif_port.value()), user, pwd)
             return
 
         # ONVIF → RTSP
@@ -407,6 +410,7 @@ class CameraModule(QtCore.QObject):
         self._start_player(url, force_tcp=self.force_tcp.isChecked(), user=user, pwd=pwd)
         # פרסום הגדרות PTZ
         self._publish_ptz_cfg()
+        self._start_ptz_meta(h, int(self.onvif_port.value()), user, pwd)
 
     # ===== Quick tools =====
     def _quick_check(self):
@@ -491,6 +495,12 @@ class CameraModule(QtCore.QObject):
             self.video.player().stop()
         except Exception:
             pass
+        if self._ptz_meta:
+            try:
+                self._ptz_meta.stop()
+            except Exception:
+                pass
+            self._ptz_meta = None
 
     def _start_manual_record(self):
         if self.recorder.is_active():
@@ -756,3 +766,20 @@ class CameraModule(QtCore.QObject):
             self._log("Shared PTZ cfg published.")
         except Exception as e:
             self._log(f"Failed to publish PTZ cfg: {e}")
+
+    def _start_ptz_meta(self, host: str, port: int, user: str, pwd: str):
+        """מפעיל thread טלמטריית PTZ עם כתיבה ל-CSV."""
+        if self._ptz_meta:
+            try:
+                self._ptz_meta.stop()
+            except Exception:
+                pass
+            self._ptz_meta = None
+        try:
+            csv_path = str(Path.cwd() / 'ptz_log.csv')
+            self._ptz_meta = PtzMetaThread(host, port, user, pwd, poll_hz=5.0,
+                                          csv_path=csv_path)
+            self._ptz_meta.start()
+            self._log(f"PTZ telemetry logging -> {csv_path}")
+        except Exception as e:
+            self._log(f"Failed to start PTZ telemetry: {e}")


### PR DESCRIPTION
## Summary
- add `PtzMetaThread` that polls ONVIF PTZ, computes rates & HFOV, and logs to CSV
- expose latest PTZ data via `shared_state.ptz_meta`
- start/stop telemetry thread from camera UIs

## Testing
- `pytest`
- `python -m py_compile onvif_ptz.py onvif_rtsp_app_ui.py ui_cam_module.py shared_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68c18afd5d68832c939e82ec8c04add9