### PR TITLE
Implement log redaction for credentials and IPs

### DIFF
--- a/onvif_rtsp_app_ui.py
+++ b/onvif_rtsp_app_ui.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 
 from PySide6 import QtCore, QtGui, QtWidgets
 import vlc
+from ui_common import redact
 
 from camera_io import (
     which,
@@ -907,7 +908,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     # ===== Logs =====
     def _log(self, s: str):
-        self.logs.appendPlainText(f"{time.strftime('%H:%M:%S')}  {s}")
+        self.logs.appendPlainText(f"{time.strftime('%H:%M:%S')}  {redact(s)}")
 
 
 # ------------------- main -------------------

--- a/ui_cam_module.py
+++ b/ui_cam_module.py
@@ -22,7 +22,7 @@ from camera_io import (
 from onvif_ptz import PtzMetaThread
 from ptz_cgi import PtzCgiThread
 
-from ui_common import VlcVideoWidget, default_vlc_path, open_folder
+from ui_common import VlcVideoWidget, default_vlc_path, open_folder, redact
 import shared_state  # <<< לשיתוף הגדרות ה-PTZ עם מודולים אחרים
 
 APP_DIR = Path(__file__).resolve().parent
@@ -848,7 +848,8 @@ class CameraModule(QtCore.QObject):
 
     # ---- logging ----
     def _log(self, s: str):
-        line = f"{time.strftime('%H:%M:%S')}  {s}"
+        red = redact(s)
+        line = f"{time.strftime('%H:%M:%S')}  {red}"
         try:
             self.logs.appendPlainText(line)  # local pane
         except Exception:

--- a/ui_common.py
+++ b/ui_common.py
@@ -3,7 +3,7 @@
 # -*- coding: utf-8 -*-
 # Common UI helpers and widgets reused across modules.
 
-import platform, subprocess
+import platform, subprocess, re
 from pathlib import Path
 from PySide6 import QtCore, QtWidgets
 import vlc
@@ -25,6 +25,17 @@ def open_folder(folder: Path):
             subprocess.Popen(["xdg-open", str(folder)])
     except Exception:
         pass
+
+
+def redact(text: str) -> str:
+    """Mask credentials and IPv4 addresses in any log line."""
+    if not text:
+        return text
+    # Mask user:pass in RTSP URLs
+    text = re.sub(r'rtsp://([^:@/\s]+):([^@/\s]+)@', r'rtsp://[USER]:[***]@', text)
+    # Mask IPv4 addresses
+    text = re.sub(r'\b(?:\d{1,3}\.){3}\d{1,3}\b', '[IP]', text)
+    return text
 
 class VlcVideoWidget(QtWidgets.QFrame):
     """Reusable VLC video surface for embedding into modules."""


### PR DESCRIPTION
## Summary
- Add shared `redact()` helper to scrub RTSP credentials and IPv4 addresses
- Sanitize log output in camera and main UI modules using the new helper

## Testing
- `python -m py_compile ui_common.py ui_cam_module.py onvif_rtsp_app_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_68c19545aaa4832c9929393a56b2577d