### PR TITLE
Persist camera map position in project

### DIFF
--- a/project_io.py
+++ b/project_io.py
@@ -69,7 +69,8 @@ def _expand_path(s: str, base: Path) -> str:
 def export_project(out_path: Path, profile: Dict[str, Any] | str, bundle_name: str,
                    dtm_path: str, ortho_path: str, *,
                    profiles_path: Path = PROFILES_PATH,
-                   srs: str = "EPSG:4326", project_name: str | None = None) -> Path:
+                   srs: str = "EPSG:4326", project_name: str | None = None,
+                   camera_position: Dict[str, Any] | None = None) -> Path:
     """Create a .rtgproj file that unifies profile, bundle and layers.
 
     Parameters
@@ -90,6 +91,9 @@ def export_project(out_path: Path, profile: Dict[str, Any] | str, bundle_name: s
         Spatial reference system code for the layers.
     project_name : str, optional
         Human friendly name for the project. Defaults to the profile's name.
+    camera_position : dict, optional
+        Optional camera XY position on the map. Structure:
+        ``{"x": float, "y": float, "epsg": int|None}``.
     """
     out_path = Path(out_path)
     base = out_path.parent
@@ -124,6 +128,13 @@ def export_project(out_path: Path, profile: Dict[str, Any] | str, bundle_name: s
             "srs": srs,
         },
     }
+
+    if camera_position:
+        data["camera_position"] = {
+            "x": float(camera_position.get("x", 0.0)),
+            "y": float(camera_position.get("y", 0.0)),
+            "epsg": camera_position.get("epsg"),
+        }
 
     out_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
     return out_path

--- a/tests/test_project_io.py
+++ b/tests/test_project_io.py
@@ -29,7 +29,8 @@ def test_export_and_load_project(tmp_path, monkeypatch):
         "roll_offset_deg": 2.2,
         "pitch_offset_deg": 3.3,
     }
-    export_project(project_path, profile, "b1", str(dtm), str(ortho))
+    cam_pos = {"x": 10.0, "y": 20.0, "epsg": 4326}
+    export_project(project_path, profile, "b1", str(dtm), str(ortho), camera_position=cam_pos)
 
     data = load_project(project_path)
     assert data["camera"]["name"] == "cam1"
@@ -39,3 +40,4 @@ def test_export_and_load_project(tmp_path, monkeypatch):
     assert data["bundle"]["name"] == "b1"
     assert Path(data["layers"]["dtm"]) == dtm
     assert Path(data["bundle"]["terrain_path"]).name == "mesh.obj"
+    assert data["camera_position"] == cam_pos


### PR DESCRIPTION
## Summary
- save camera XY location in project files and restore when opening
- redraw camera marker after loading projects
- test project IO roundtrip including camera position

## Testing
- `PYTHONPATH=. pytest tests/test_project_io.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*


------
https://chatgpt.com/codex/tasks/task_e_68c4f93bf88c832c8552c9dce86acd54