### PR TITLE
Improve Dahua CGI polling robustness

### DIFF
--- a/parser_dahua.py
+++ b/parser_dahua.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+def parse_cgi_status(text: str):
+    """Parse Dahua CGI status text into a dict.
+
+    Returns a dict with pan/tilt/zoom values and a raw mapping of all keys.
+    Accepts various key spellings such as Position/Positon/AbsPosition and
+    ZoomValue/ZoomMapValue.
+    """
+    raw: dict[str, str] = {}
+    for part in text.replace("&", "\n").splitlines():
+        line = part.strip()
+        if not line or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        raw[k.strip()] = v.strip()
+
+    def pick_float(keys):
+        for k in keys:
+            if k in raw:
+                try:
+                    return float(raw[k])
+                except Exception:
+                    pass
+        return None
+
+    pan = pick_float(["status.Position[0]", "status.Positon[0]", "status.AbsPosition[0]", "pan"])
+    tilt = pick_float(["status.Position[1]", "status.Positon[1]", "status.AbsPosition[1]", "tilt"])
+    zoom = pick_float([
+        "status.ZoomValue",
+        "status.Position[2]",
+        "status.Positon[2]",
+        "status.AbsPosition[2]",
+        "status.ZoomMapValue",
+        "zoom",
+    ])
+    focus = pick_float(["status.FocusValue", "focus"])
+    return {"pan": pan, "tilt": tilt, "zoom": zoom, "focus": focus, "raw": raw}

--- a/ptz_csv_logger.py
+++ b/ptz_csv_logger.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import csv
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+_PTZ_CSV_LOCK = threading.Lock()
+_PTZ_CSV_PATH = Path.cwd() / "ptz_log.csv"
+_PTZ_DBG_PATH = Path.cwd() / "ptz_debug.log"
+
+
+def _csv_header():
+    return [
+        "ts_utc",
+        "source",
+        "channel",
+        "auth",
+        "http_code",
+        "pan",
+        "tilt",
+        "zoom",
+        "body_len",
+        "parse_err",
+        "url",
+    ]
+
+
+def log_ptz_row(
+    *,
+    source: str,
+    url: str,
+    http_code: int,
+    channel: int,
+    auth: str,
+    body: str,
+    parsed: dict | None,
+    err: str | None,
+) -> None:
+    ts = datetime.now(timezone.utc).isoformat()
+    pan = parsed.get("pan") if parsed else None
+    tilt = parsed.get("tilt") if parsed else None
+    zoom = parsed.get("zoom") if parsed else None
+    row = [
+        ts,
+        source,
+        channel,
+        auth,
+        http_code,
+        pan,
+        tilt,
+        zoom,
+        len(body or ""),
+        (err or "")[:160],
+        url,
+    ]
+
+    with _PTZ_CSV_LOCK:
+        new_file = not _PTZ_CSV_PATH.exists()
+        with open(_PTZ_CSV_PATH, "a", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            if new_file:
+                w.writerow(_csv_header())
+            w.writerow(row)
+            f.flush()
+            os.fsync(f.fileno())
+
+    if err:
+        with open(_PTZ_DBG_PATH, "a", encoding="utf-8") as g:
+            g.write(f"{ts} ERR={err} URL={url}\nBODY:\n{(body or '')[:1000]}\n---\n")


### PR DESCRIPTION
## Summary
- Add tolerant Dahua CGI status parser that handles common key variants and keeps raw fields
- Introduce thread-safe CSV logger with immediate fsync and debug log of parse errors
- Integrate new parser and logger into PTZ CGI polling thread for reliable state updates

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c503115cfc832c8364f8f1eff07979