### PR TITLE
Add digest auth support and separate CGI log files

### DIFF
--- a/ptz_cgi.py
+++ b/ptz_cgi.py
@@ -10,6 +10,7 @@ from typing import Optional
 from urllib.error import URLError
 from urllib.request import (
     HTTPBasicAuthHandler,
+    HTTPDigestAuthHandler,
     HTTPPasswordMgrWithDefaultRealm,
     Request,
     build_opener,
@@ -100,8 +101,9 @@ class PtzCgiThread:
         mgr = HTTPPasswordMgrWithDefaultRealm()
         for url in self._urls:
             mgr.add_password(None, url, self.user, self.pwd)
-        handler = HTTPBasicAuthHandler(mgr)
-        self._opener = build_opener(handler)
+        basic = HTTPBasicAuthHandler(mgr)
+        digest = HTTPDigestAuthHandler(mgr)
+        self._opener = build_opener(basic, digest)
 
     def _fetch_text(self) -> Optional[str]:
         if not self._opener:
@@ -179,7 +181,7 @@ class PtzCgiThread:
                     url=self._urls[self._url_index],
                     http_code=200,
                     channel=self.channel,
-                    auth="Basic",
+                    auth="Basic/Digest",
                     body=txt,
                     parsed=parsed,
                     err=err,
@@ -235,7 +237,7 @@ class PtzCgiThread:
                     url=self._urls[self._url_index],
                     http_code=-1,
                     channel=self.channel,
-                    auth="Basic",
+                    auth="Basic/Digest",
                     body="",
                     parsed={},
                     err="no response",

--- a/ptz_csv_logger.py
+++ b/ptz_csv_logger.py
@@ -7,8 +7,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 _PTZ_CSV_LOCK = threading.Lock()
-_PTZ_CSV_PATH = Path.cwd() / "ptz_log.csv"
-_PTZ_DBG_PATH = Path.cwd() / "ptz_debug.log"
+_PTZ_CSV_PATH = Path.cwd() / "ptz_cgi_log.csv"
+_PTZ_DBG_PATH = Path.cwd() / "ptz_cgi_debug.log"
 
 
 def _csv_header():


### PR DESCRIPTION
## Summary
- log PTZ CGI telemetry to dedicated `ptz_cgi_log.csv` and `ptz_cgi_debug.log`
- support HTTP digest authentication alongside basic auth
- label CGI log entries with `Basic/Digest` auth type

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5077ad6f8832cad57a8a9ed39ca52