### PR TITLE
Default to PTZ+DTM mapping

### DIFF
--- a/ui_img2ground_module.py
+++ b/ui_img2ground_module.py
@@ -671,6 +671,7 @@ class Img2GroundModule(QtCore.QObject):
         rowp = QtWidgets.QHBoxLayout()
         self.cmb_mapping = QtWidgets.QComboBox()
         self.cmb_mapping.addItems(["Auto (prefer Homography)", "Homography only", "PTZ+DTM only"])
+        self.cmb_mapping.setCurrentIndex(2)
         self.btn_pick_now = QtWidgets.QPushButton("Pick now"); self.btn_pick_now.clicked.connect(self._pick_now_snapshot)
         self.btn_pick_now.setToolTip("לכידת פריים ותרגום לנ״צ/‏XY; נשלח גם ל-QR.")
         rowp.addWidget(QtWidgets.QLabel("Mapping mode:")); rowp.addWidget(self.cmb_mapping)

--- a/ui_user_module.py
+++ b/ui_user_module.py
@@ -49,6 +49,7 @@ class UserTab(QtWidgets.QWidget):
         self.act_az = bar.addAction("Toggle Azimuth")
         self.cmb_mapping = QtWidgets.QComboBox()
         self.cmb_mapping.addItems(["Auto (prefer Homography)", "Homography only", "PTZ+DTM only"])
+        self.cmb_mapping.setCurrentIndex(2)
         bar.addWidget(self.cmb_mapping)
 
         # ----- video + map -----


### PR DESCRIPTION
## Summary
- default mapping mode to `PTZ+DTM only` in user and img2ground modules for PTZ/DTM workflows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5082b1120832caf6a6a75ffd8f835