### PR TITLE
Log CGI HTTP errors

### DIFF
--- a/tests/test_ptz_cgi_thread.py
+++ b/tests/test_ptz_cgi_thread.py
@@ -13,7 +13,7 @@ class DummyPtzCgi(PtzCgiThread):
         super().__init__("localhost", 80, "u", "p", poll_hz=100.0)
 
     def _fetch_text(self):  # override network call
-        return "pan=1.0&tilt=2.0&zoom=0.25&focus=3.0"
+        return "pan=1.0&tilt=2.0&zoom=0.25&focus=3.0", 200
 
 
 def test_ptz_cgi_thread_shared_state():


### PR DESCRIPTION
## Summary
- Capture HTTP status codes in PTZ CGI polling
- Log non-200 responses instead of generic `no response`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50a90b808832c8a8d40cad2a592a4