### PR TITLE
Handle PTZ CGI status without channel parameter

### DIFF
--- a/ptz_cgi.py
+++ b/ptz_cgi.py
@@ -39,7 +39,7 @@ class PtzCgiThread:
         port: int,
         user: str,
         pwd: str,
-        channel: int = 1,
+        channel: Optional[int] = 1,
         poll_hz: float = 5.0,
         https: bool = False,
         csv_path: Optional[str] = None,
@@ -54,14 +54,15 @@ class PtzCgiThread:
         self._csv_path = csv_path
 
         proto = "https" if https else "http"
-        urls = [
+        base_urls = [
             f"{proto}://{host}:{port}/cgi-bin/ptz.cgi?action=getStatus",
             f"{proto}://{host}:{port}/ptz.cgi?action=getStatus",
             f"{proto}://{host}:{port}/cgi-bin/ptz?action=getStatus",
             f"{proto}://{host}:{port}/ptz?action=getStatus",
         ]
+        urls = base_urls.copy()
         if channel is not None:
-            urls = [u + f"&channel={int(channel)}" for u in urls]
+            urls = [u + f"&channel={int(channel)}" for u in base_urls] + urls
         self._urls = urls
         self._url_index = 0
 

--- a/tests/test_ptz_cgi_thread.py
+++ b/tests/test_ptz_cgi_thread.py
@@ -28,3 +28,11 @@ def test_ptz_cgi_thread_shared_state():
     assert meta["focus_pos"] == 3.0
     assert meta.get("cgi_last", {}).get("pan_deg") == 1.0
     assert th.last().focus_pos == 3.0
+
+
+def test_ptz_cgi_urls_try_channel_and_without():
+    th = PtzCgiThread("host", 80, "u", "p", channel=1)
+    urls = th._urls
+    base = "http://host:80/cgi-bin/ptz.cgi?action=getStatus"
+    assert base in urls
+    assert base + "&channel=1" in urls


### PR DESCRIPTION
## Summary
- Attempt PTZ CGI status requests both with and without the `channel` query parameter
- Add regression test ensuring URL list includes channel and non-channel variants

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c50dfd6e80832c92cab58896f63f56