### PR TITLE
Handle non-finite DEM elevations

### DIFF
--- a/core/i2g_core.py
+++ b/core/i2g_core.py
@@ -155,7 +155,10 @@ def intersect_ray_with_dem(
     while t <= max_range_m:
         p = o + d * t
         elev = dem.elevation(float(p[0]), float(p[1]))
-        if elev is not None and p[2] <= elev:
+        if elev is None or not math.isfinite(elev):
+            t += step_m
+            continue
+        if p[2] <= elev:
             return float(p[0]), float(p[1]), float(elev)
         t += step_m
     return None


### PR DESCRIPTION
## Summary
- Skip ray-march steps when DEM elevation is NaN or infinite to avoid false intersections
- Add unit test ensuring non-finite elevations are ignored during ray-DEM intersection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac3e6b94832c8f7e0fa05f23cad9