### PR TITLE
Default tilt to zero when telemetry missing

### DIFF
--- a/core/i2g_core.py
+++ b/core/i2g_core.py
@@ -144,6 +144,7 @@ def image_ray(u: int, v: int, intr: Intrinsics, ptz: PTZ, extr: Extrinsics) -> T
     yaw = extr.yaw + (ptz.pan or 0.0)
     # Many PTZ cameras define positive tilt as looking downwards.
     # Subtract to keep the convention that positive pitch raises the view.
+    # If PTZ telemetry omits tilt, treat it as zero.
     pitch = extr.pitch - (ptz.tilt or 0.0)
     roll = extr.roll
     R = _rotation_matrix(yaw, pitch, roll)

--- a/tests/test_i2g_core.py
+++ b/tests/test_i2g_core.py
@@ -47,6 +47,15 @@ def test_image_ray_tilt_sign():
     assert down_dir[2] < 0.0
 
 
+def test_image_ray_missing_tilt_defaults_zero():
+    """If tilt telemetry is missing, it should default to zero."""
+    intr = Intrinsics.from_hfov(400, 300, 90.0)
+    extr = Extrinsics(0.0, 0.0, 0.0, 0.0, 5.0, 0.0, 4326)
+    _, dir_none = image_ray(200, 150, intr, PTZ(0.0, None, None), extr)
+    _, dir_zero = image_ray(200, 150, intr, PTZ(0.0, 0.0, None), extr)
+    assert np.allclose(dir_none, dir_zero)
+
+
 def test_intersect_flat_dem():
     intr = Intrinsics.from_hfov(400, 300, 90.0)
     extr = Extrinsics(0.0, 0.0, 10.0, -90.0, 45.0, 0.0, 4326)


### PR DESCRIPTION
## Summary
- Clarify that missing tilt telemetry is treated as zero in `image_ray`
- Add regression test ensuring default tilt behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ba09025c832caf9c55b84ff0c8c0