### PR TITLE
Add guard when clearing orthophoto scenes

### DIFF
--- a/ui_img2ground_module.py
+++ b/ui_img2ground_module.py
@@ -982,8 +982,12 @@ class Img2GroundModule(QtCore.QObject):
             except Exception:
                 n_before = -1
             print(f"[I2G.apply_ortho] before clear: items={n_before}")
-            sc.clear()
+            it = self._ortho_pix
             self._ortho_pix = None
+            try:
+                sc.clear()
+            finally:
+                it = None
             try:
                 n_after = len(sc.items())
             except Exception:

--- a/ui_prep_module.py
+++ b/ui_prep_module.py
@@ -422,10 +422,15 @@ class PrepModule(QtCore.QObject):
             except Exception:
                 n_before = -1
             print(f"[Prep._load_orthophoto] before clear: items={n_before}")
-            sc.clear()
-            # clear python references to deleted graphics items
+            dtm = self._dtm_pixmap
+            ortho = self._ortho_pixmap
             self._dtm_pixmap = None
             self._ortho_pixmap = None
+            try:
+                sc.clear()
+            finally:
+                dtm = None
+                ortho = None
             try:
                 n_after = len(sc.items())
             except Exception:


### PR DESCRIPTION
## Summary
- Prevent late references to deleted QGraphicsItems by clearing scene with temporary references in ui_img2ground_module
- Apply same guard for prep module's DTM and orthophoto pixmaps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb81efc8832c9fe98ecdc914a943